### PR TITLE
Fix bug where minimax could pass its turn near end-game 

### DIFF
--- a/othello.py
+++ b/othello.py
@@ -122,7 +122,7 @@ def minimax(board, depth, maximizing, player):
     if depth == 0 or game.is_game_over():
         return evaluate_board(game.board), None
 
-    valid_moves = game.get_valid_moves(player)
+    valid_moves = game.get_valid_moves(player) or [None]
     best_move = None
 
     if maximizing:


### PR DESCRIPTION
Pass its turn even though there are valid moves, because float -inf or +inf was returned from a child branch.
Minimax still has to explore the None move, even if it's the only move at that turn, just so it can calculate the correct value.
I have examples of board configurations that trigger this. 